### PR TITLE
S3 이미지 경로 분리 적용 및 기본 이미지 & 이름 사용하도록 적용

### DIFF
--- a/src/main/java/site/packit/packit/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/site/packit/packit/domain/auth/service/CustomOAuth2UserService.java
@@ -101,8 +101,8 @@ public class CustomOAuth2UserService
                 CreateMemberDto.of(
                         userInfo.getId(),
                         userInfo.getEmail(),
-                        memberDefaultNickname,
-                        memberDefaultProfileImageUrl,
+                        userInfo.getName(),
+                        userInfo.getProfileImageUrl(),
                         memberDefaultListCheckLimitCount,
                         authenticationProvider
                 )

--- a/src/main/java/site/packit/packit/domain/image/service/AmazonS3ImageService.java
+++ b/src/main/java/site/packit/packit/domain/image/service/AmazonS3ImageService.java
@@ -23,9 +23,11 @@ public class AmazonS3ImageService
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    private static final String PROFILE_IMAGE_PATH = "profile-images";
+
     @Override
     public String uploadImage(MultipartFile image) throws IOException {
-        String storedImageName = getStoredImageName(Objects.requireNonNull(image.getOriginalFilename()));
+        String storedImageName = PROFILE_IMAGE_PATH + "/" + getStoredImageName(Objects.requireNonNull(image.getOriginalFilename()));
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(image.getSize());


### PR DESCRIPTION
- S3내부에 이미지 종류별로 폴더를 분리하고 이를 코드에 반영하였다.
- OAuth2 인증 시 기본 이미지와 이름을 프로바이더에서 제공한 리소스를 사용하도록 변경하였다.

This closes #22 