### PR TITLE
프로필 이미지 변경 API 입력 타입 변경

### DIFF
--- a/src/main/java/site/packit/packit/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/site/packit/packit/domain/auth/service/CustomOAuth2UserService.java
@@ -32,7 +32,7 @@ public class CustomOAuth2UserService
     private final MemberService memberService;
 
     // TODO : 기획에 따라 변경
-    private static final String DEFAULT_PROFILE_IMAGE_URL ="https://dnd--pack-it.s3.ap-northeast-2.amazonaws.com/profile-images/default-profile-image.png";
+    private static final String DEFAULT_PROFILE_IMAGE_URL ="https://dnd--pack-it.s3.ap-northeast-2.amazonaws.com/profile-images/1.svg";
 
     public CustomOAuth2UserService(
             MemberRepository memberRepository,

--- a/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
+++ b/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
@@ -3,7 +3,6 @@ package site.packit.packit.domain.member.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import site.packit.packit.domain.auth.info.CustomUserPrincipal;
 import site.packit.packit.domain.image.service.ImageService;
 import site.packit.packit.domain.member.dto.ChangeNicknameRequest;
@@ -12,8 +11,6 @@ import site.packit.packit.domain.member.service.MemberService;
 import site.packit.packit.domain.travel.service.TravelService;
 import site.packit.packit.global.response.success.SingleSuccessApiResponse;
 import site.packit.packit.global.response.success.SuccessApiResponse;
-
-import java.io.IOException;
 
 @RequestMapping("/api/members")
 @RestController
@@ -68,13 +65,12 @@ public class MemberController {
     @PutMapping("/profile-images")
     public ResponseEntity<SuccessApiResponse> updateMemberProfileImage(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            MultipartFile image
-    ) throws IOException {
+            @RequestBody String profileImageUrl
+    ) {
         memberService.updateMemberProfileImageUrl(
                 principal.getMemberId(),
-                imageService.uploadImage(image)
+                profileImageUrl
         );
-
         return ResponseEntity.ok(
                 SuccessApiResponse.of(
                         "성공적으로 프로필이미지가 변경되었습니다."

--- a/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
+++ b/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import site.packit.packit.domain.auth.info.CustomUserPrincipal;
 import site.packit.packit.domain.image.service.ImageService;
 import site.packit.packit.domain.member.dto.ChangeNicknameRequest;
 import site.packit.packit.domain.member.dto.MemberWithTravelCountDto;
+import site.packit.packit.domain.member.dto.UpdateMemberRequest;
 import site.packit.packit.domain.member.service.MemberService;
 import site.packit.packit.domain.travel.service.TravelService;
 import site.packit.packit.global.response.success.SingleSuccessApiResponse;
@@ -74,6 +75,20 @@ public class MemberController {
         return ResponseEntity.ok(
                 SuccessApiResponse.of(
                         "성공적으로 프로필이미지가 변경되었습니다."
+                )
+        );
+    }
+
+    @PatchMapping
+    public ResponseEntity<SuccessApiResponse> updateMember(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @RequestBody UpdateMemberRequest request
+    ) {
+        memberService.updateMemberNickname(principal.getMemberId(), request.nickname());
+        memberService.updateMemberProfileImageUrl(principal.getMemberId(), request.image());
+        return ResponseEntity.ok(
+                SuccessApiResponse.of(
+                        "성공적으로 회원정보가 변경되었습니다."
                 )
         );
     }

--- a/src/main/java/site/packit/packit/domain/member/dto/UpdateMemberRequest.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/UpdateMemberRequest.java
@@ -1,0 +1,7 @@
+package site.packit.packit.domain.member.dto;
+
+public record UpdateMemberRequest(
+        String nickname,
+        String image
+) {
+}


### PR DESCRIPTION
- 회원 정보 수정시 닉네임과 프로필 이미지 url을 동시에 받을 수 있는 API 생성
- 사용자 기본 프로필 이미지 변경

This closes #44 